### PR TITLE
Fix background tab animations throttling...

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -15,3 +15,16 @@
 .damage-info {
   @apply border border-transparent bg-neutral-50 rounded px-2 py-1 text-neutral-600 text-sm cursor-default;
 }
+
+@keyframes attack {
+  0% {
+    transform: translateY(0px) scale(1, 1);
+  }
+  50% {
+    transform: translateY(-4px) scale(1.05, 1.05);
+    background: transparent;
+  }
+  100% {
+    transform: translateY(0px) scale(1,1);
+  }
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -40,10 +40,12 @@ liveSocket.connect()
 window.liveSocket = liveSocket
 
 // Battlefield Animations
-window.addEventListener('phx:animate', (e) => {
+window.addEventListener('phx:animate', function (e) {
   let el = document.getElementById(e.detail.id)
 
   if (el) {
-    liveSocket.execJS(el, el.getAttribute("data-animation"))
+    setTimeout(function () {
+      el.style.animation = 'attack linear 0.1s'
+    }, 25)
   }
 })

--- a/lib/frostmount_web/live/battlefield.ex
+++ b/lib/frostmount_web/live/battlefield.ex
@@ -154,9 +154,6 @@ defmodule FrostmountWeb.Battlefield do
   defp avatar_image(n),
     do: "minion-#{n}.png"
 
-  def animate_attack(element_id),
-    do: JS.transition(%JS{}, "animate-attack", to: element_id, time: 100)
-
   defp extra_heal_points(members),
     do: members |> Enum.count() |> Kernel.div(2)
 end

--- a/lib/frostmount_web/live/battlefield.html.heex
+++ b/lib/frostmount_web/live/battlefield.html.heex
@@ -28,7 +28,6 @@
     >
       <div
         id={"member-#{member.uuid}"}
-        data-animation={animate_attack("#member-#{member.uuid}")}
         class="text-center w-12 lg:w-20"
       >
         <!-- The images of minions are taken from the DuckDuckGo search results -->


### PR DESCRIPTION
We noticed a weird bug: if a connected player switches to another tab, so the Frostmount's Battlefield goes background, and other players actively hit the Beast, when the original player opens the tab again they see “retrospectively” all the activity that happened (like an instant replay). It goes until all the attack animation events got handled.

That happens in Chrome (not in Safari, for example).

After some experiments, we concluded that this is due to the nature of how LiveView handles JS.transition and how Chrome aggressively throttles the animations in background tabs (to preserve CPU and thus device battery).

Unfortunately, we cannot easily set (or toggle) CSS class on custom LiveView event in the JavaScript because the underlying library (`morphdom`) and the way how LiveView handles DOM patches, instantly removes new classes from our elements.

However, we can ~~leverage~~ hack it with `setTimeout` with little delay: this way allows us to run our JS callback asynchronously and _after_ `morphdom` patches.

Seems, this ~~hack~~ workaround works…

## Screencaptures

### Before

<video src="https://github.com/cr0t/frostmount/assets/113878/7b8cca10-693e-49f7-8750-82f9819fa50c"></video>

### After

<video src="https://github.com/cr0t/frostmount/assets/113878/7f8d5ed0-d7ea-4559-becc-ce7b52a127ce"></video>
